### PR TITLE
Add option to refit the background removing peaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ plot_plumes(df_co2$CO2_ppm, df_co2$time_nano, plumes)
 ![the extracted plumes highlighted on the concentration time-series](images/plumes_r.png)
 
 Once the plumes have been finalised, the area under the plumes can be calculated using a trapezoidal approach.
-It's crucial to subtract the background from the concentration time-series for this function.
+It's crucial to subtract the background from the concentration time-series for this function (note that the background is held in the `bg` attribute of the result from `identify_background`).
 
 ```r
-co2_areas <- integrate_aup_trapz(df_co2$CO2_ppm - bg_gam, df_co2$time_nano, plumes, dx=0.1)
+co2_areas <- integrate_aup_trapz(df_co2$CO2_ppm - bg_gam$bg, df_co2$time_nano, plumes, dx=0.1)
 co2_areas
 ```
 

--- a/acruiseR/DESCRIPTION
+++ b/acruiseR/DESCRIPTION
@@ -9,7 +9,7 @@ License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
     license
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Imports:
     dplyr,
     data.table,

--- a/acruiseR/man/detect_plumes.Rd
+++ b/acruiseR/man/detect_plumes.Rd
@@ -10,15 +10,15 @@ detect_plumes(
   time,
   plume_sd_threshold = 3,
   plume_sd_starting = 2,
-  plume_buffer = 10
+  plume_buffer = 10,
+  refit = FALSE
 )
 }
 \arguments{
 \item{concentration}{Concentration time-series as a vector.}
 
-\item{background}{The smoothed background time-series, as can be
-obtained from \code{identify_background}. Must have the same
-length as \code{concentration}.}
+\item{background}{The smoothed background time-series object, as can be
+obtained from \code{identify_background}}
 
 \item{time}{The time-series as a vector of POSIX or nanotime.
 Must have the same length as \code{concentration}.}
@@ -28,11 +28,15 @@ must exceed to be defined as a plume.}
 
 \item{plume_sd_starting}{Once a plume has been identified due to it
 crossing \code{plume_sd_threshold}, its duration is considered as the
-times when it is more than this many standard deviatiations above the
+times when it is more than this many standard deviations above the
 background.}
 
 \item{plume_buffer}{A buffer in seconds applied to plumes, so
 that if they are overlapping they are merged into the same plume.}
+
+\item{refit}{If TRUE, removes the identified plumes from the time-series
+to recalculate the background, then re-identifies plumes. Should result in
+a smoother background and therefore more accurate plume estimation.}
 }
 \value{
 A Data Frame where each row corresponds to a unique plume, whose

--- a/acruiseR/man/identify_background.Rd
+++ b/acruiseR/man/identify_background.Rd
@@ -44,8 +44,9 @@ background, as an integer. Used only
 when \code{method='rolling'}.}
 }
 \value{
-A vector with the same length as \code{concentration} containing the
-smoothed background.
+A list containing the background (slot \code{bg}) which is
+a vector with the same length as \code{concentration}, and the arguments
+used in this call (slot \code{call}).
 }
 \description{
 This process takes 3 steps:

--- a/acruiseR/man/plot_background.Rd
+++ b/acruiseR/man/plot_background.Rd
@@ -22,16 +22,15 @@ plot_background(
 \item{time}{The time-series as a vector of POSIX or nanotime.
 Must have the same length as \code{concentration}.}
 
-\item{background}{The smoothed background time-series, as can be
-obtained from \code{identify_background}. Must have the same
-length as \code{concentration}.}
+\item{background}{The smoothed background time-series object, as can be
+obtained from \code{identify_background}}
 
 \item{plume_sd_threshold}{The number of standard deviations that a sample
 must exceed to be defined as a plume.}
 
 \item{plume_sd_starting}{Once a plume has been identified due to it
 crossing \code{plume_sd_threshold}, its duration is considered as the
-times when it is more than this many standard deviatiations above the
+times when it is more than this many standard deviations above the
 background.}
 
 \item{ylabel}{y-axis label}


### PR DESCRIPTION
I've added a `refit` option to `detect_peaks` (default FALSE) to address #4, have a play with it on your noisy dataset @tedgluxe and see what you think. It doesn't currently let you plot the new background but I can add that in later if the refitting meets your needs.

You can install this update by using `remotes::install_github("https://github.com/wacl-york/acruise-peakid", subdir="acruiseR", ref="feature/refit-baseline-remove-peaks")`
If that command isn't working then I will need to make the repository public, would that be ok? I can't see why any of this code should be sensitive and there's no data stored here.

