### PR TITLE
Clear CMD CHECK Notes

### DIFF
--- a/acruiseR/DESCRIPTION
+++ b/acruiseR/DESCRIPTION
@@ -2,8 +2,7 @@ Package: acruiseR
 Title: Identifies Peaks from ACRUISE Measurements
 Version: 0.1.0
 Authors@R: 
-    person("Stuart", "Lacy", , "stuart.lacy@york.ac.uk", role = c("aut", "cre"),
-           comment = c(ORCID = "YOUR-ORCID-ID"))
+    person("Stuart", "Lacy", , "stuart.lacy@york.ac.uk", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
 License: MIT + file ../LICENSE
 Encoding: UTF-8
@@ -13,6 +12,7 @@ Imports:
     data.table,
     forecast,
     ggplot2,
+    lubridate,
     mgcv,
     nanotime,
     pracma,

--- a/acruiseR/DESCRIPTION
+++ b/acruiseR/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.1.0
 Authors@R: 
     person("Stuart", "Lacy", , "stuart.lacy@york.ac.uk", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
-License: MIT + file ../LICENSE
+License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/acruiseR/LICENSE
+++ b/acruiseR/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2025
+COPYRIGHT HOLDER: acruiseR authors

--- a/acruiseR/LICENSE.md
+++ b/acruiseR/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2025 acruiseR authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
0 errors ✔ | 0 warnings ✔ | 0 notes ✔

 - Sorts out global bindings, mainly for `data.table` by setting them as NULL (based on advice from [data.table docs](https://cran.r-project.org/web/packages/data.table/vignettes/datatable-importing.html#globals)
 - Adds the license to the R directory, duplicating the one in the tld, but now satisfies check
 - imports `lubridate` and adds some package specifications for other undefined functions
 - removes the `acruisepy` file that wasn't needed
